### PR TITLE
feat: reworked entire tab/spaces system, fixed a lot of issues

### DIFF
--- a/Fastedit/Controls/TextStatusBar.xaml
+++ b/Fastedit/Controls/TextStatusBar.xaml
@@ -56,14 +56,29 @@
         </controls:StatusbarItem>
         <controls:StatusbarItem Grid.Column="6" HorizontalAlignment="Left" StaticText="" x:Name="ItemTabsSpaces">
             <controls:StatusbarItem.CustomFlyout>
-                <MenuFlyout x:Name="TabsSpacesFlyout" Opened="TabsSpacesFlyout_Opened">
-                    <RadioMenuFlyoutItem Text="Use Tab (\t)" Click="TabSpaces_Click" Tag="-1"/>
-                    <MenuFlyoutSeparator/>
-                    <RadioMenuFlyoutItem Text="2 Spaces" Click="TabSpaces_Click" Tag="2"/>
-                    <RadioMenuFlyoutItem Text="4 Spaces" Click="TabSpaces_Click" Tag="4"/>
-                    <RadioMenuFlyoutItem Text="8 Spaces" Click="TabSpaces_Click" Tag="8"/>
-                    <RadioMenuFlyoutItem Text="12 Spaces" Click="TabSpaces_Click" Tag="12"/>
-                    <RadioMenuFlyoutItem Text="16 Spaces" Click="TabSpaces_Click" Tag="16"/>
+                <MenuFlyout Opening="ItemTabsSpaces_FlyoutOpening">
+                    <!-- Tab key behavior -->
+                    <MenuFlyoutSubItem Text="Tab Key" x:Name="ItemTabKeyBehaviour">
+                        <MenuFlyoutSubItem.Items>
+                            <ToggleMenuFlyoutItem Text="Use Tab (\t)" Click="TabSpaces_Click" Tag="-1"/>
+                            <MenuFlyoutSeparator/>
+                            <ToggleMenuFlyoutItem Text="2 Spaces" Click="TabSpaces_Click" Tag="2"/>
+                            <ToggleMenuFlyoutItem Text="4 Spaces" Click="TabSpaces_Click" Tag="4"/>
+                            <ToggleMenuFlyoutItem Text="8 Spaces" Click="TabSpaces_Click" Tag="8"/>
+                        </MenuFlyoutSubItem.Items>
+                    </MenuFlyoutSubItem>
+
+                    <!-- Reformat entire text -->
+                    <MenuFlyoutSubItem Text="Reformat Document">
+                        <MenuFlyoutSubItem.Items>
+                            <MenuFlyoutItem Text="Use Tab (\t)" Click="ReformatTabsInDocument_Click" Tag="-1"/>
+                            <MenuFlyoutSeparator/>
+                            <MenuFlyoutItem Text="2 Spaces" Click="ReformatTabsInDocument_Click" Tag="2"/>
+                            <MenuFlyoutItem Text="4 Spaces" Click="ReformatTabsInDocument_Click" Tag="4"/>
+                            <MenuFlyoutItem Text="8 Spaces" Click="ReformatTabsInDocument_Click" Tag="8"/>
+                        </MenuFlyoutSubItem.Items>
+                    </MenuFlyoutSubItem>
+
                 </MenuFlyout>
             </controls:StatusbarItem.CustomFlyout>
         </controls:StatusbarItem>

--- a/Fastedit/Controls/TextStatusBar.xaml.cs
+++ b/Fastedit/Controls/TextStatusBar.xaml.cs
@@ -206,7 +206,6 @@ public sealed partial class TextStatusBar : UserControl
 
         tabPage.DatabaseItem.IsModified = true;
         tabPage.LineEnding = lineEnding;
-        UpdateLineEndings();
     }
 
     private void ChangeEncoding_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -280,28 +279,16 @@ public sealed partial class TextStatusBar : UserControl
 
     private void TabSpaces_Click(object sender, RoutedEventArgs e)
     {
-        if (this.tabPage == null)
-            return;
-
-        int tabs = ConvertHelper.ToInt((sender as RadioMenuFlyoutItem).Tag, -1);
-        tabPage.SetTabsSpaces(tabs);
+        TabsSpacesHelper.SetTabsSpaces(tabPage, sender);
     }
 
-    private void TabsSpacesFlyout_Opened(object sender, object e)
+    private void ReformatTabsInDocument_Click(object sender, RoutedEventArgs e)
     {
-        string tag = (tabPage.textbox.UseSpacesInsteadTabs ? tabPage.textbox.NumberOfSpacesForTab : -1).ToString();
+        TabsSpacesHelper.RewriteTabsSpaces(tabPage, sender);
+    }
 
-        foreach (MenuFlyoutItemBase item in TabsSpacesFlyout.Items)
-        {
-            if (item is RadioMenuFlyoutItem radioItem)
-            {
-                if (radioItem.Tag.Equals(tag))
-                {
-                    radioItem.IsChecked = true;
-                    continue;
-                }
-                radioItem.IsChecked = false;
-            }
-        }
+    private void ItemTabsSpaces_FlyoutOpening(object sender, object e)
+    {
+        TabsSpacesHelper.SelectToggleMenuItemsFromMenu(ItemTabKeyBehaviour, tabPage);
     }
 }

--- a/Fastedit/Core/Settings/AppSettings.cs
+++ b/Fastedit/Core/Settings/AppSettings.cs
@@ -1,6 +1,7 @@
 ﻿using Fastedit.Core.Settings;
 using Microsoft.UI.Windowing;
 using System.Diagnostics;
+using TextControlBoxNS;
 
 internal class AppSettings
 {
@@ -153,5 +154,10 @@ internal class AppSettings
     {
         get => SettingsManager.GetSettingsAsBool(AppSettingsValues.Settings_EnableClickableLinks, DefaultValues.EnableClickableLinks);
         set => SettingsManager.SaveSettings(AppSettingsValues.Settings_EnableClickableLinks, value);
+    }
+    public static LineEnding DefaultLineEnding
+    {
+        get => (LineEnding)SettingsManager.GetSettingsAsInt(AppSettingsValues.Settings_DefaultLineEnding, LineEnding.CRLF.GetHashCode());
+        set => SettingsManager.SaveSettings(AppSettingsValues.Settings_DefaultLineEnding, value.GetHashCode());
     }
 }

--- a/Fastedit/Core/Settings/AppSettings.cs
+++ b/Fastedit/Core/Settings/AppSettings.cs
@@ -64,16 +64,11 @@ internal class AppSettings
         set => SettingsManager.SaveSettings(AppSettingsValues.Settings_NewTabExtension, value);
     }
 
-    public static bool UseSpacesInsteadTabs
+    public static int TabsSpacesMode
     {
-        get => SettingsManager.GetSettingsAsBool(AppSettingsValues.Settings_UseSpacesInsteadTabs, DefaultValues.UseSpacesInsteadTabs);
-        set => SettingsManager.SaveSettings(AppSettingsValues.Settings_UseSpacesInsteadTabs, value);
-    }
-
-    public static int SpacesPerTab
-    {
-        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.Settings_SpacesPerTab, DefaultValues.NumberOfSpacesPerTab);
-        set => SettingsManager.SaveSettings(AppSettingsValues.Settings_SpacesPerTab, value);
+        //-1 for tab, >0 for spaces
+        get => SettingsManager.GetSettingsAsInt(AppSettingsValues.Settings_TabsSpacesMode, DefaultValues.DefaultTabsSpaces);
+        set => SettingsManager.SaveSettings(AppSettingsValues.Settings_TabsSpacesMode, value);
     }
 
     public static bool ShowStatusbar

--- a/Fastedit/Core/Settings/AppSettingsValues.cs
+++ b/Fastedit/Core/Settings/AppSettingsValues.cs
@@ -15,6 +15,7 @@ public static class AppSettingsValues
     public const string Settings_NewTabTitle = "NewTabTitle";
     public const string Settings_NewTabExtension = "NewTabExtension";
 
+    public const string Settings_DefaultLineEnding = "DefaultLineEnding";
     public const string Settings_TabsSpacesMode = "TabsSpacesMode";
     public const string Settings_ShowWhitespaceCharacters = "ShowWhitespaceCharacters";
     public const string Settings_EnableClickableLinks = "EnableClickableLinks";

--- a/Fastedit/Core/Settings/AppSettingsValues.cs
+++ b/Fastedit/Core/Settings/AppSettingsValues.cs
@@ -15,8 +15,7 @@ public static class AppSettingsValues
     public const string Settings_NewTabTitle = "NewTabTitle";
     public const string Settings_NewTabExtension = "NewTabExtension";
 
-    public const string Settings_UseSpacesInsteadTabs = "UseSpacesInsteadTabs";
-    public const string Settings_SpacesPerTab = "SpacesPerTab";
+    public const string Settings_TabsSpacesMode = "TabsSpacesMode";
     public const string Settings_ShowWhitespaceCharacters = "ShowWhitespaceCharacters";
     public const string Settings_EnableClickableLinks = "EnableClickableLinks";
 

--- a/Fastedit/Core/Settings/DefaultValues.cs
+++ b/Fastedit/Core/Settings/DefaultValues.cs
@@ -9,7 +9,7 @@ namespace Fastedit.Core.Settings
     {
         public static string NewTabTitle = "Untitled";
         public static string NewTabExtension = ".txt";
-        public static Encoding Encoding = Encoding.UTF8;
+        public static Encoding Encoding = new UTF8Encoding(false);
         public static bool FastLoadTabs = true;
         public static string DatabasePath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "Database");
         public static string DesignPath = Path.Combine(ApplicationData.Current.LocalFolder.Path, "Designs");
@@ -20,7 +20,6 @@ namespace Fastedit.Core.Settings
         public static int FontSize = 18;
         public static bool ShowLineHighlighter = true;
         public static bool ShowLinenumbers = true;
-        public static bool UseSpacesInsteadTabs = false;
         public static bool SyntaxHighlighting = true;
         public static bool ShowMenubar = true;
         public static bool ShowStatusbar = true;

--- a/Fastedit/Core/Settings/DefaultValues.cs
+++ b/Fastedit/Core/Settings/DefaultValues.cs
@@ -24,7 +24,7 @@ namespace Fastedit.Core.Settings
         public static bool SyntaxHighlighting = true;
         public static bool ShowMenubar = true;
         public static bool ShowStatusbar = true;
-        public static int NumberOfSpacesPerTab = 4;
+        public static int DefaultTabsSpaces = 4; //-1 for tabs, > 0 for spaces
         public static string DefaultDesignName = "Simple_Dark.json";
         public static Color wrongInputColor = Color.FromArgb(255, 255, 0, 0);
         public static Color correctInputColor = Color.FromArgb(255, 0, 255, 0);

--- a/Fastedit/Core/Settings/SettingsUpdater.cs
+++ b/Fastedit/Core/Settings/SettingsUpdater.cs
@@ -95,10 +95,6 @@ namespace Fastedit.Core.Settings
                     (tabView.TabItems[i] as TabViewItem).Background = DesignHelper.CreateBackgroundBrush(ConvertHelper.ToColor(currentDesign.TextBoxBackground), currentDesign.TextboxBackgroundType);
                 }
             }
-
-            //Load tabs or spaces
-            object tag = AppSettings.UseSpacesInsteadTabs ? AppSettings.SpacesPerTab : "-1";
-            TabPageHelper.TabsOrSpacesForAll(tabView, tag);
         }
         public static void SetSettingsToStatusbar(TextStatusBar statusbar, FasteditDesign design)
         {

--- a/Fastedit/Core/Tab/TabDatabase.cs
+++ b/Fastedit/Core/Tab/TabDatabase.cs
@@ -1,4 +1,5 @@
 ﻿using Fastedit.Core.Settings;
+using Fastedit.Dialogs;
 using Fastedit.Models;
 using Microsoft.UI.Xaml.Controls;
 using Newtonsoft.Json;
@@ -14,7 +15,7 @@ public class TabDatabase
 {
     string DatabaseName = "database.db";
 
-    public void SaveData(IList<object> TabItems, int SelectedIndex)
+    public bool SaveData(IList<object> TabItems, int SelectedIndex)
     {
         StringBuilder databaseBuilder = new StringBuilder();
         for (int i = 0; i < TabItems.Count; i++)
@@ -39,13 +40,22 @@ public class TabDatabase
             databaseBuilder.AppendLine(JsonConvert.SerializeObject(window.Value.DatabaseItem));
         }
 
-        string path = Path.Combine(DefaultValues.DatabasePath, DatabaseName);
-        if (!File.Exists(path))
+        try
         {
-            Directory.CreateDirectory(DefaultValues.DatabasePath);
-        }
+            string path = Path.Combine(DefaultValues.DatabasePath, DatabaseName);
+            if (!File.Exists(path))
+            {
+                Directory.CreateDirectory(DefaultValues.DatabasePath);
+            }
 
-        File.WriteAllText(path, databaseBuilder.ToString());
+            File.WriteAllText(path, databaseBuilder.ToString());
+            return true;
+        }
+        catch (Exception ex)
+        {
+            InfoMessages.ErrorSavingDatabaseFile(ex.Message);
+            return false;
+        }
     }
     public IEnumerable<TabPageItem> LoadData(TabView tabView)
     {
@@ -64,9 +74,18 @@ public class TabDatabase
         }
     }
 
-    public static void SaveTempFile(TabPageItem tab)
+    public static bool SaveTempFile(TabPageItem tab)
     {
-        File.WriteAllLines(Path.Combine(DefaultValues.DatabasePath, tab.DatabaseItem.Identifier), tab.textbox.Lines);
+        try
+        {
+            File.WriteAllLines(Path.Combine(DefaultValues.DatabasePath, tab.DatabaseItem.Identifier), tab.textbox.Lines);
+            return true;
+        }
+        catch(Exception ex)
+        {
+            InfoMessages.ErrorSavingDBTempFile(ex.Message);
+            return false;
+        }
     }
     public static void DeleteTempFile(TabPageItem tab)
     {

--- a/Fastedit/Core/Tab/TabPageItem.cs
+++ b/Fastedit/Core/Tab/TabPageItem.cs
@@ -15,7 +15,6 @@ public class TabPageItem : TabViewItem
 {
     public TextControlBox textbox { get; private set; }
     private TabView tabView;
-    private MainPage mainPage;
     
     public TabPageItem(TabView tabView, TabItemDatabaseItem databaseItem = null)
     {
@@ -198,8 +197,6 @@ public class TabPageItem : TabViewItem
         this.textbox.UseSpacesInsteadTabs = spaces != -1;
         if(spaces > 0)
             this.textbox.NumberOfSpacesForTab = spaces;
-        
-        mainPage?.SelectTabSpacesMenubarItem();
     }
 
     public void RewriteTabsSpaces(int spaces) 

--- a/Fastedit/Core/Tab/TabPageItem.cs
+++ b/Fastedit/Core/Tab/TabPageItem.cs
@@ -1,12 +1,13 @@
-﻿using Fastedit.Helper;
+﻿using Fastedit.Core.Settings;
+using Fastedit.Helper;
 using Fastedit.Models;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using System;
-using System.Text;
-using Microsoft.UI.Xaml;
-using TextControlBoxNS;
-using Fastedit.Core.Settings;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
+using TextControlBoxNS;
 
 namespace Fastedit.Core.Tab;
 
@@ -83,6 +84,10 @@ public class TabPageItem : TabViewItem
             LineEnding = LineEnding.CRLF,
         };
 
+        //newly created tab => set default tabs/spaces
+        if (item == null)
+            SetTabsSpaces(AppSettings.TabsSpacesMode);
+
         UpdateTabIcon();
     }
 
@@ -143,6 +148,8 @@ public class TabPageItem : TabViewItem
         if (Enum.TryParse(_DataBaseItem.CodeLanguage, true, out SyntaxHighlightID language))
             highlightID = language;
 
+        this.SetTabsSpaces(_DataBaseItem.TabsSpaces);
+
         textbox.SyntaxHighlighting = TextControlBox.GetSyntaxHighlightingFromID(highlightID);
     }
 
@@ -186,9 +193,25 @@ public class TabPageItem : TabViewItem
 
     public void SetTabsSpaces(int spaces = -1)
     {
+        this.DatabaseItem.TabsSpaces = spaces;
         //-1 = use tabs positive values => spaces
         this.textbox.UseSpacesInsteadTabs = spaces != -1;
         if(spaces > 0)
             this.textbox.NumberOfSpacesForTab = spaces;
+        
+        mainPage?.SelectTabSpacesMenubarItem();
+    }
+
+    public void RewriteTabsSpaces(int spaces) 
+    {
+        bool useSpaces = spaces != -1;
+        this.textbox.RewriteTabsSpaces(spaces == -1 ? 4 : spaces, useSpaces);
+    }
+
+    public void LoadLines(IEnumerable<string> lines, bool autodetectTabsSpaces = true, LineEnding lineEnding = LineEnding.CRLF)
+    {
+        this.textbox.LoadLines(lines, autodetectTabsSpaces, lineEnding);
+        int spaces = this.textbox.UseSpacesInsteadTabs ? this.textbox.NumberOfSpacesForTab : -1;
+        this.DatabaseItem.TabsSpaces = spaces;
     }
 }

--- a/Fastedit/Core/Tab/TabPageItem.cs
+++ b/Fastedit/Core/Tab/TabPageItem.cs
@@ -81,7 +81,7 @@ public class TabPageItem : TabViewItem
             FilePath = "",
             IsModified = false,
             ZoomFactor = 100,
-            LineEnding = LineEnding.CRLF,
+            LineEnding = AppSettings.DefaultLineEnding,
         };
 
         //newly created tab => set default tabs/spaces

--- a/Fastedit/Dialogs/InfoMessages.cs
+++ b/Fastedit/Dialogs/InfoMessages.cs
@@ -8,6 +8,8 @@ namespace Fastedit.Dialogs;
 public class InfoMessages
 {
     public static void NoAccessToSaveFile() => new InfoBar().Show("No access", "No access to write to the file", InfoBarSeverity.Error);
+    public static void ErrorSavingDatabaseFile(string message) => new InfoBar().Show("Saving Database Error", message, InfoBarSeverity.Error);
+    public static void ErrorSavingDBTempFile(string message) => new InfoBar().Show("Saving open file error", message, InfoBarSeverity.Error);
     public static void NoAccessToReadFile() => new InfoBar().Show("No access", "No access to read from the file", InfoBarSeverity.Error);
     public static void UnhandledException(string message) => new InfoBar().Show("Exception", "Unhandled exception:\n" + message, InfoBarSeverity.Error);
     public static void ClearRecycleBinError() => new InfoBar().Show("Clear Recycle Bin", "An error occurred while clearing the Recycle Bin", InfoBarSeverity.Error);

--- a/Fastedit/Fastedit.csproj
+++ b/Fastedit/Fastedit.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
 	  <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250916003" />
 	  <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
-	  <PackageReference Include="TextControlBox.WinUI.JuliusKirsch" Version="1.4.0" />
+	  <PackageReference Include="TextControlBox.WinUI.JuliusKirsch" Version="1.5.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/Fastedit/Helper/LineEndingHelper.cs
+++ b/Fastedit/Helper/LineEndingHelper.cs
@@ -1,7 +1,9 @@
-﻿using Fastedit.Models;
+﻿using Fastedit.Core.Tab;
+using Fastedit.Models;
 using Microsoft.UI.Xaml.Controls;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using TextControlBoxNS;
 
 namespace Fastedit.Helper;
@@ -28,7 +30,20 @@ internal class LineEndingHelper
     {
         foreach (var lineEnding in GetLineEndings())
         {
-            var item = new MenuFlyoutItem { Text = lineEnding.ToString() };
+            var item = new MenuFlyoutItem { Text = lineEnding.ToString(), Tag = lineEnding };
+            item.Click += (sender, e) =>
+            {
+                lineEndingSelected?.Invoke(lineEnding);
+            };
+
+            yield return item;
+        }
+    }
+    private static IEnumerable<RadioMenuFlyoutItem> MakeRadioItems(Action<LineEnding> lineEndingSelected)
+    {
+        foreach (var lineEnding in GetLineEndings())
+        {
+            var item = new RadioMenuFlyoutItem { Text = lineEnding.ToString(), Tag = lineEnding };
             item.Click += (sender, e) =>
             {
                 lineEndingSelected?.Invoke(lineEnding);
@@ -67,7 +82,23 @@ internal class LineEndingHelper
 
     public static void MakeAndAddLineEndingItems(MenuFlyoutSubItem subItem, Action<LineEnding> lineEndingSelected)
     {
-        foreach (var item in MakeItems(lineEndingSelected))
+        foreach (var item in MakeRadioItems(lineEndingSelected))
             subItem.Items.Add(item);
+    }
+
+    public static void SelectItems(IList<MenuFlyoutItemBase> items, TabPageItem tabPage)
+    {
+        if (tabPage == null || tabPage.textbox == null)
+            return;
+
+        foreach (var item in items)
+        {
+            if(item is RadioMenuFlyoutItem radioItem && 
+               radioItem.Tag is LineEnding lineEnding)
+            {
+                radioItem.IsChecked = tabPage.LineEnding == lineEnding;
+                return;
+            }
+        }
     }
 }

--- a/Fastedit/Helper/SettingsTabPageHelper.cs
+++ b/Fastedit/Helper/SettingsTabPageHelper.cs
@@ -1,8 +1,9 @@
-﻿using Fastedit.Models;
+﻿using Fastedit.Core.Tab;
+using Fastedit.Models;
 using Fastedit.Views;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml;
-using Fastedit.Core.Tab;
+using Microsoft.UI.Xaml.Controls;
+
 
 namespace Fastedit.Helper;
 
@@ -52,7 +53,14 @@ public class SettingsTabPageHelper
     }
     public static void CloseSettings(TabView tabView)
     {
+        //this check prevents a crash, happing when closing the settings tab while it is selected
+        //I think it is a problem with tabview!
+        if (tabView.SelectedIndex == 0 && IsSettingsPage(tabView.SelectedItem))
+        {
+            tabView.SelectedIndex = 1;
+        }
         tabView.TabItems.Remove(settingsPage);
+
         SettingsPageOpen = SettingsSelected = false;
         SettingsTabClosed?.Invoke();
     }

--- a/Fastedit/Helper/TabsSpacesHelper.cs
+++ b/Fastedit/Helper/TabsSpacesHelper.cs
@@ -1,0 +1,56 @@
+﻿using Fastedit.Core.Tab;
+using Microsoft.UI.Xaml.Controls;
+using System.Collections.Generic;
+using System.Diagnostics;
+using TextControlBoxNS;
+
+namespace Fastedit.Helper;
+
+internal class TabsSpacesHelper
+{
+    public static void SelectRadioItemFromMenu(MenuFlyout tabsSpacesflyout, TabPageItem tabPage)
+    {
+        string tag = (tabPage.textbox.UseSpacesInsteadTabs ? tabPage.textbox.NumberOfSpacesForTab : -1).ToString();
+
+        IterateItems(tabsSpacesflyout.Items, tag);
+    }
+
+    private static void IterateItems(IList<MenuFlyoutItemBase> items, string tag)
+    {
+        foreach (MenuFlyoutItemBase item in items)
+        {
+            if (item is ToggleMenuFlyoutItem radioItem)
+            {
+                radioItem.IsChecked = radioItem.Tag.ToString().Equals(tag);
+            }
+        }
+    }
+
+    public static void SelectToggleMenuItemsFromMenu(MenuFlyoutSubItem tabsSpacesflyout, TabPageItem tabPage)
+    {
+        if (tabPage == null || tabPage.textbox == null)
+            return;
+
+        string tag = (tabPage.textbox.UseSpacesInsteadTabs ? tabPage.textbox.NumberOfSpacesForTab : -1).ToString();
+        IterateItems(tabsSpacesflyout.Items, tag);
+    }
+
+    public static void SetTabsSpaces(TabPageItem tabPage, object sender)
+    {
+        if (tabPage == null)
+            return;
+
+        int spaces = ConvertHelper.ToInt((sender as MenuFlyoutItem).Tag, -1);
+        tabPage.SetTabsSpaces(spaces);
+
+    }
+
+    public static void RewriteTabsSpaces(TabPageItem tabPage, object sender)
+    {
+        if (tabPage == null)
+            return;
+
+        int spaces = ConvertHelper.ToInt((sender as MenuFlyoutItem).Tag, -1);
+        tabPage.RewriteTabsSpaces(spaces);
+    }
+}

--- a/Fastedit/Models/TabItemDatabaseItem.cs
+++ b/Fastedit/Models/TabItemDatabaseItem.cs
@@ -18,7 +18,7 @@ namespace Fastedit.Models
         public int LinePos { get; set; }
         public LineEnding LineEnding { get; set; }
         public bool? WhitespaceCharacters { get; set; } = null;
-
+        public int TabsSpaces { get; set; } = -1;
         [JsonIgnore]
         public bool WasNeverSaved => this.FilePath.Length == 0;
     }

--- a/Fastedit/Views/MainPage.xaml
+++ b/Fastedit/Views/MainPage.xaml
@@ -607,15 +607,25 @@
                 <MenuBarItem Title="Advanced">
                     <MenuBarItem.Items>
                         <MenuFlyoutSubItem Text="Syntax Highlighting" x:Name="CodeLanguageSelector"/>
-                        <MenuFlyoutSubItem Text="Tabs / Spaces" x:Name="TabsSpacesMenubarFlyout">
+                        <MenuFlyoutSeparator/>
+                        <MenuFlyoutSubItem Text="Tab Behaviour (Tabs/Spaces)" x:Name="TabKeyBehaviourFlyout">
                             <MenuFlyoutSubItem.Items>
-                                <MenuFlyoutItem Text="Use Tab (\t)" Click="TabSpaces_Click" Tag="-1"/>
+                                <MenuFlyoutItem Text="Auto Detect" Click="AutodetectTabsSpaces_Click"/>
                                 <MenuFlyoutSeparator/>
-                                <RadioMenuFlyoutItem Text="2 Spaces" Click="TabSpaces_Click" Tag="2"/>
-                                <RadioMenuFlyoutItem Text="4 Spaces" Click="TabSpaces_Click" Tag="4"/>
-                                <RadioMenuFlyoutItem Text="8 Spaces" Click="TabSpaces_Click" Tag="8"/>
-                                <RadioMenuFlyoutItem Text="12 Spaces" Click="TabSpaces_Click" Tag="12"/>
-                                <RadioMenuFlyoutItem Text="16 Spaces" Click="TabSpaces_Click" Tag="16"/>
+                                <ToggleMenuFlyoutItem Text="Use Tab (\t)" Click="TabSpaces_Click" Tag="-1"/>
+                                <MenuFlyoutSeparator/>
+                                <ToggleMenuFlyoutItem Text="2 Spaces" Click="TabSpaces_Click" Tag="2" />
+                                <ToggleMenuFlyoutItem Text="4 Spaces" Click="TabSpaces_Click" Tag="4"/>
+                                <ToggleMenuFlyoutItem Text="8 Spaces" Click="TabSpaces_Click" Tag="8"/>
+                            </MenuFlyoutSubItem.Items>
+                        </MenuFlyoutSubItem>
+                        <MenuFlyoutSubItem Text="Reformat Tabs/Spaces">
+                            <MenuFlyoutSubItem.Items>
+                                <MenuFlyoutItem Text="Use Tab (\t)" Click="ReformatTabsInDocument_Click" Tag="-1"/>
+                                <MenuFlyoutSeparator/>
+                                <MenuFlyoutItem Text="2 Spaces" Click="ReformatTabsInDocument_Click" Tag="2"/>
+                                <MenuFlyoutItem Text="4 Spaces" Click="ReformatTabsInDocument_Click" Tag="4"/>
+                                <MenuFlyoutItem Text="8 Spaces" Click="ReformatTabsInDocument_Click" Tag="8"/>
                             </MenuFlyoutSubItem.Items>
                         </MenuFlyoutSubItem>
                         <MenuFlyoutSeparator/>
@@ -692,14 +702,20 @@
                 <models:QuickAccessWindowItem Command="Select All" Shortcut="Ctrl + A" RunCommandWindowItemClicked="SelectAll_Click"/>
                 <models:QuickAccessWindowItem Command="Reload Settings" Shortcut="Ctrl + Shift + R" RunCommandWindowItemClicked="ReloadSettings_Click"/>
                 <models:QuickAccessWindowItem Command="Rename" Shortcut="F2" RunCommandWindowItemClicked="RenameFile_Click"/>
-                <models:QuickAccessWindowSubItem Command="Tabs/Spaces">
+                <models:QuickAccessWindowSubItem Command="Tab Key Behaviour (Tabs/Spaces)">
                     <models:QuickAccessWindowSubItem.Items>
                         <models:QuickAccessWindowItem Command="Tabs" Tag="-1" RunCommandWindowItemClicked="TabSpaces_Click"/>
                         <models:QuickAccessWindowItem Command="2" Tag="2" RunCommandWindowItemClicked="TabSpaces_Click"/>
                         <models:QuickAccessWindowItem Command="4" Tag="4" RunCommandWindowItemClicked="TabSpaces_Click"/>
                         <models:QuickAccessWindowItem Command="8" Tag="8" RunCommandWindowItemClicked="TabSpaces_Click"/>
-                        <models:QuickAccessWindowItem Command="12" Tag="12" RunCommandWindowItemClicked="TabSpaces_Click"/>
-                        <models:QuickAccessWindowItem Command="16" Tag="16" RunCommandWindowItemClicked="TabSpaces_Click"/>
+                    </models:QuickAccessWindowSubItem.Items>
+                </models:QuickAccessWindowSubItem>
+                <models:QuickAccessWindowSubItem Command="Reformat Tabs/Spaces">
+                    <models:QuickAccessWindowSubItem.Items>
+                        <models:QuickAccessWindowItem Command="Tabs" Tag="-1" RunCommandWindowItemClicked="ReformatTabsInDocument_Click"/>
+                        <models:QuickAccessWindowItem Command="2" Tag="2" RunCommandWindowItemClicked="ReformatTabsInDocument_Click"/>
+                        <models:QuickAccessWindowItem Command="4" Tag="4" RunCommandWindowItemClicked="ReformatTabsInDocument_Click"/>
+                        <models:QuickAccessWindowItem Command="8" Tag="8" RunCommandWindowItemClicked="ReformatTabsInDocument_Click"/>
                     </models:QuickAccessWindowSubItem.Items>
                 </models:QuickAccessWindowSubItem>
                 <models:QuickAccessWindowSubItem Command="Line Ending" x:Name="RunCommandWindowItem_LineEndings"/>

--- a/Fastedit/Views/MainPage.xaml.cs
+++ b/Fastedit/Views/MainPage.xaml.cs
@@ -98,7 +98,7 @@ public sealed partial class MainPage : Page
             title = $"{tab.Header}";
         else if (SettingsTabPageHelper.IsSettingsPage(tabControl.SelectedItem))
             title = "Fastedit - Settings";
-            App.m_window.Title = title;
+        App.m_window.Title = title;
     }
     private void Initialise()
     {
@@ -152,7 +152,10 @@ public sealed partial class MainPage : Page
             return;
         }
 
-        SaveDatabase();
+        if (!SaveDatabase())
+        {
+            args.Cancel = true;
+        }
     }
 
     private void tabControl_TabDragStarting(TabView sender, TabViewTabDragStartingEventArgs args)
@@ -624,9 +627,9 @@ public sealed partial class MainPage : Page
     {
         tabControl.SelectedItem = tab;
     }
-    public void SaveDatabase(bool ShowProgress = true, bool closeWindows = true)
+    public bool SaveDatabase(bool ShowProgress = true, bool closeWindows = true)
     {
-        TabPageHelper.SaveTabDatabase(tabdatabase, tabControl, ShowProgress ? progressWindow : null, closeWindows);
+        return TabPageHelper.SaveTabDatabase(tabdatabase, tabControl, ShowProgress ? progressWindow : null, closeWindows);
     }
     public void ShowSettings(string page = null)
     {

--- a/Fastedit/Views/SettingsPages/Settings_AppPage.xaml
+++ b/Fastedit/Views/SettingsPages/Settings_AppPage.xaml
@@ -50,6 +50,7 @@
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="*"/>
                             <RowDefinition Height="*"/>
+                            <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
@@ -74,8 +75,8 @@
                         <TextBlock x:Uid="Settings_App_LineEndingsText" FontSize="16" Text="Line Endings" Grid.Row="5" Grid.Column="0"/>
                         <ToggleSwitch x:Name="showLineEndings" Tag="5" Grid.Row="5" Grid.Column="1" Toggled="Statusbar_ShowItem_Toggled" Style="{StaticResource LeftSideToggleSwitch}"/>
 
-                        <TextBlock x:Uid="Settings_App_TabsSpacesText" FontSize="16" Text="Tab Spaces" Grid.Row="5" Grid.Column="0"/>
-                        <ToggleSwitch x:Name="showTabsSpaces" Tag="5" Grid.Row="5" Grid.Column="1" Toggled="Statusbar_ShowItem_Toggled" Style="{StaticResource LeftSideToggleSwitch}"/>
+                        <TextBlock x:Uid="Settings_App_TabsSpacesText" FontSize="16" Text="Tab Spaces" Grid.Row="6" Grid.Column="0"/>
+                        <ToggleSwitch x:Name="showTabsSpaces" Tag="5" Grid.Row="6" Grid.Column="1" Toggled="Statusbar_ShowItem_Toggled" Style="{StaticResource LeftSideToggleSwitch}"/>
                     </Grid>
                 </Expander.Content>
             </Expander>

--- a/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml
+++ b/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml
@@ -59,7 +59,7 @@
             </controls:SettingsControl.Content>
         </controls:SettingsControl>
 
-        <controls:SetingsItemSeparator x:Uid="Settings_Page_Tab_Key_Separator" Header="Tab/Spaces"/>
+        <controls:SetingsItemSeparator x:Uid="Settings_Page_Tab_Key_Separator" Header="Default Document Settings"/>
         <controls:SettingsControl x:Uid="Settings_Page_Number_Of_Spaces_Per_Tab_Control" Header="Default Tab behaviour for new documents">
             <controls:SettingsControl.Content>
                 <ComboBox Width="200" x:Name="TabsSpacesSelectorCombobox" SelectionChanged="TabsSpacesSelectorCombobox_SelectionChanged">
@@ -67,6 +67,17 @@
                     <ComboBoxItem Content="2 Spaces" Tag="2"/>
                     <ComboBoxItem Content="4 Spaces" Tag="4"/>
                     <ComboBoxItem Content="8 Spaces" Tag="8"/>
+                </ComboBox>
+            </controls:SettingsControl.Content>
+        </controls:SettingsControl>
+        <controls:SettingsControl Header="Default Line Ending for new Documents">
+            <controls:SettingsControl.Content>
+                <ComboBox ItemsSource="{x:Bind LineEndings}" Width="200" x:Name="LineEndingSelectorCombobox" SelectionChanged="LineEndingSelectorCombobox_SelectionChanged">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="x:String">
+                            <TextBlock Text="{x:Bind}" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
                 </ComboBox>
             </controls:SettingsControl.Content>
         </controls:SettingsControl>

--- a/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml
+++ b/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d">
 
     <StackPanel VerticalAlignment="Top">
-        <controls:SetingsItemSeparator x:Uid="Settings_Page_Text_Separator" Header="Text"/>
+        <controls:SetingsItemSeparator x:Uid="Settings_Page_Text_Separator" Header="Text Styling"/>
         <controls:SettingsControl x:Uid="Settings_Page_Font_Family_Control" Header="Font Family">
             <controls:SettingsControl.Content>
                 <ComboBox ItemsSource="{x:Bind Fonts}" SelectionChanged="FontFamilyCombobox_SelectionChanged" x:Name="FontFamilyCombobox" Width="200">
@@ -28,7 +28,7 @@
             </controls:SettingsControl.Content>
         </controls:SettingsControl>
 
-        <controls:SetingsItemSeparator x:Uid="Settings_Page_Features_Separator" Header="Features"/>
+        <controls:SetingsItemSeparator x:Uid="Settings_Page_Features_Separator" Header="Enable/Disable Features"/>
 
         <controls:SettingsControl x:Uid="Settings_Page_Show_Line_Numbers_Control" Header="Show Line Numbers">
             <controls:SettingsControl.Content>
@@ -59,15 +59,15 @@
             </controls:SettingsControl.Content>
         </controls:SettingsControl>
 
-            <controls:SetingsItemSeparator x:Uid="Settings_Page_Tab_Key_Separator" Header="Tab Key"/>
-        <controls:SettingsControl x:Uid="Settings_Page_Use_Spaces_Instead_Tabs_Control" Header="Use Spaces Instead of Tabs (\t)">
+        <controls:SetingsItemSeparator x:Uid="Settings_Page_Tab_Key_Separator" Header="Tab/Spaces"/>
+        <controls:SettingsControl x:Uid="Settings_Page_Number_Of_Spaces_Per_Tab_Control" Header="Default Tab behaviour for new documents">
             <controls:SettingsControl.Content>
-                <ToggleSwitch x:Name="SpacesOrTabsSwitch" Toggled="SpacesOrTabsSwitch_Toggled" Style="{StaticResource LeftSideToggleSwitch}"/>
-            </controls:SettingsControl.Content>
-        </controls:SettingsControl>
-        <controls:SettingsControl x:Uid="Settings_Page_Number_Of_Spaces_Per_Tab_Control" Header="Number of Spaces Per Tab">
-            <controls:SettingsControl.Content>
-                <Slider Width="200" IsEnabled="{x:Bind SpacesOrTabsSwitch.IsOn, Mode=TwoWay}" Value="{x:Bind settings:DefaultValues.NumberOfSpacesPerTab, Mode=OneTime}" StepFrequency="2" Maximum="16" Minimum="2" TickPlacement="Inline" x:Name="SpacesPerTabSlider" ValueChanged="SpacesPerTabSlider_ValueChanged"/>
+                <ComboBox Width="200" x:Name="TabsSpacesSelectorCombobox" SelectionChanged="TabsSpacesSelectorCombobox_SelectionChanged">
+                    <ComboBoxItem Content="Tabs" Tag="-1"/>
+                    <ComboBoxItem Content="2 Spaces" Tag="2"/>
+                    <ComboBoxItem Content="4 Spaces" Tag="4"/>
+                    <ComboBoxItem Content="8 Spaces" Tag="8"/>
+                </ComboBox>
             </controls:SettingsControl.Content>
         </controls:SettingsControl>
     </StackPanel>

--- a/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml.cs
+++ b/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml.cs
@@ -19,9 +19,15 @@ public sealed partial class Settings_DocumentPage : Page
         }
     }
 
+    public string[] LineEndings
+    {
+        get => LineEndingHelper.GetLineEndings().Select(item => item.ToString()).ToArray();
+    }
+
     public Settings_DocumentPage()
     {
         this.InitializeComponent();
+
 
         int tabsSpaces = AppSettings.TabsSpacesMode;
         TabsSpacesSelectorCombobox.SelectedItem = 
@@ -38,6 +44,9 @@ public sealed partial class Settings_DocumentPage : Page
 
         ShowWhitespaceCharacters.IsOn = AppSettings.ShowWhitespaceCharacters;
         EnableClickableLinks.IsOn = AppSettings.EnableClickableLinks;
+
+        LineEndingSelectorCombobox.SelectedIndex = AppSettings.DefaultLineEnding.GetHashCode();
+
     }
 
 
@@ -78,5 +87,10 @@ public sealed partial class Settings_DocumentPage : Page
     private void TabsSpacesSelectorCombobox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         AppSettings.TabsSpacesMode = ConvertHelper.ToInt((TabsSpacesSelectorCombobox.SelectedItem as ComboBoxItem).Tag, DefaultValues.DefaultTabsSpaces);
+    }
+
+    private void LineEndingSelectorCombobox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        AppSettings.DefaultLineEnding = (TextControlBoxNS.LineEnding)LineEndingSelectorCombobox.SelectedIndex;
     }
 }

--- a/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml.cs
+++ b/Fastedit/Views/SettingsPages/Settings_DocumentPage.xaml.cs
@@ -3,8 +3,8 @@ using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Fastedit.Core.Settings;
+using Fastedit.Helper;
 
 
 namespace Fastedit.Views.SettingsPages;
@@ -23,9 +23,11 @@ public sealed partial class Settings_DocumentPage : Page
     {
         this.InitializeComponent();
 
-        var value = AppSettings.SpacesPerTab;
-        SpacesPerTabSlider.Value = value == -1 ? DefaultValues.NumberOfSpacesPerTab : value;
-        SpacesOrTabsSwitch.IsOn = AppSettings.UseSpacesInsteadTabs;
+        int tabsSpaces = AppSettings.TabsSpacesMode;
+        TabsSpacesSelectorCombobox.SelectedItem = 
+            TabsSpacesSelectorCombobox.Items.First(
+                item => ConvertHelper.ToInt((item as ComboBoxItem).Tag.ToString(), DefaultValues.DefaultTabsSpaces) == tabsSpaces
+                );
 
         FontFamilyCombobox.SelectedItem = AppSettings.FontFamily;
         FontSizeNumberBox.Value = AppSettings.FontSize;
@@ -38,14 +40,6 @@ public sealed partial class Settings_DocumentPage : Page
         EnableClickableLinks.IsOn = AppSettings.EnableClickableLinks;
     }
 
-    private void SpacesOrTabsSwitch_Toggled(object sender, RoutedEventArgs e)
-    {
-        AppSettings.UseSpacesInsteadTabs = SpacesOrTabsSwitch.IsOn;
-    }
-    private void SpacesPerTabSlider_ValueChanged(object sender, RangeBaseValueChangedEventArgs e)
-    {
-        AppSettings.SpacesPerTab = (int)SpacesPerTabSlider.Value;
-    }
 
     private void FontFamilyCombobox_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
@@ -79,5 +73,10 @@ public sealed partial class Settings_DocumentPage : Page
     private void EnableClickableLinks_Toggled(object sender, RoutedEventArgs e)
     {
         AppSettings.EnableClickableLinks = EnableClickableLinks.IsOn;
+    }
+
+    private void TabsSpacesSelectorCombobox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        AppSettings.TabsSpacesMode = ConvertHelper.ToInt((TabsSpacesSelectorCombobox.SelectedItem as ComboBoxItem).Tag, DefaultValues.DefaultTabsSpaces);
     }
 }


### PR DESCRIPTION
I reworked the whole system how tabs and spaces work, especially in the upcoming release of TextControlBox (1.5.0). 

- Tabs and spaces are NO more getting (fixed/unified/overwritten) on opening the file. Only if requested by the user. 
- The tab character behaviour can be set apart of the indentation in the document
- Reduced the tab/spaces selection to \t, 2, 4, 8 for a simpler interface
- Added simpler default setting in the settings with a simple combobox
- Added auto detection for the current indentation used in opened documents
- Added rewrite tabs option to change the whole documents indentation.
- Added an indicator for the current indentation #169 
  